### PR TITLE
Add LinkedIn info and improve layout

### DIFF
--- a/src/components/TheFormation.vue
+++ b/src/components/TheFormation.vue
@@ -2,57 +2,30 @@
 </script>
 
 <template>
-  <ul class="list bg-base-100 rounded-box shadow-md">
-
-    <li class="p-4 pb-2 text-xs opacity-60 tracking-wide">Most played songs this week</li>
-
-    <li class="list-row">
-      <div class="text-4xl font-thin opacity-30 tabular-nums">01</div>
-      <div><img class="size-10 rounded-box" src="https://img.daisyui.com/images/profile/demo/1@94.webp" /></div>
-      <div class="list-col-grow">
-        <div>Dio Lupa</div>
-        <div class="text-xs uppercase font-semibold opacity-60">Remaining Reason</div>
-      </div>
-      <button class="btn btn-square btn-ghost">
-        <svg class="size-[1.2em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-          <g stroke-linejoin="round" stroke-linecap="round" stroke-width="2" fill="none" stroke="currentColor">
-            <path d="M6 3L20 12 6 21 6 3z"></path>
-          </g>
-        </svg>
-      </button>
-    </li>
-
-    <li class="list-row">
-      <div class="text-4xl font-thin opacity-30 tabular-nums">02</div>
-      <div><img class="size-10 rounded-box" src="https://img.daisyui.com/images/profile/demo/4@94.webp" /></div>
-      <div class="list-col-grow">
-        <div>Ellie Beilish</div>
-        <div class="text-xs uppercase font-semibold opacity-60">Bears of a fever</div>
-      </div>
-      <button class="btn btn-square btn-ghost">
-        <svg class="size-[1.2em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-          <g stroke-linejoin="round" stroke-linecap="round" stroke-width="2" fill="none" stroke="currentColor">
-            <path d="M6 3L20 12 6 21 6 3z"></path>
-          </g>
-        </svg>
-      </button>
-    </li>
-
-    <li class="list-row">
-      <div class="text-4xl font-thin opacity-30 tabular-nums">03</div>
-      <div><img class="size-10 rounded-box" src="https://img.daisyui.com/images/profile/demo/3@94.webp" /></div>
-      <div class="list-col-grow">
-        <div>Sabrino Gardener</div>
-        <div class="text-xs uppercase font-semibold opacity-60">Cappuccino</div>
-      </div>
-      <button class="btn btn-square btn-ghost">
-        <svg class="size-[1.2em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-          <g stroke-linejoin="round" stroke-linecap="round" stroke-width="2" fill="none" stroke="currentColor">
-            <path d="M6 3L20 12 6 21 6 3z"></path>
-          </g>
-        </svg>
-      </button>
-    </li>
-
-  </ul>
+  <div class="card bg-base-100 shadow-md animate-cartaBottom">
+    <div class="card-body">
+      <h2 class="card-title">Experiencia</h2>
+      <ul class="space-y-2 text-sm">
+        <li>
+          <strong>Brain2Store</strong> - Desarrollador full stack<br />
+          <span class="opacity-70">mayo 2024 - Actualidad | Sant Cugat del Vallès</span>
+        </li>
+        <li>
+          <strong>Saint-Gobain</strong> - Desarrollador full stack<br />
+          <span class="opacity-70">mayo 2023 - mayo 2024 | l'Arboç</span>
+        </li>
+      </ul>
+      <h2 class="card-title pt-4">Educación</h2>
+      <ul class="space-y-2 text-sm">
+        <li>
+          <strong>Institut Camí de Mar</strong> - ASIR<br />
+          <span class="opacity-70">sept. 2024 - may. 2025</span>
+        </li>
+        <li>
+          <strong>Institut Camí de Mar</strong> - DAW<br />
+          <span class="opacity-70">sept. 2022 - may. 2024</span>
+        </li>
+      </ul>
+    </div>
+  </div>
 </template>

--- a/src/components/ThePersonalCard.vue
+++ b/src/components/ThePersonalCard.vue
@@ -2,57 +2,19 @@
 </script>
 
 <template>
-  <ul class="list bg-base-100 rounded-box shadow-2xl">
-    <h3 class="text-4xl">NACHO DE LA TORRE PLANAS</h3>
-    <li class="p-4 pb-2 text-xs opacity-60 tracking-wide">Most played songs this week</li>
-
-    <li class="list-row">
-      <div class="text-4xl font-thin opacity-30 tabular-nums">01</div>
-      <div><img class="size-10 rounded-box" src="https://img.daisyui.com/images/profile/demo/1@94.webp" /></div>
-      <div class="list-col-grow">
-        <div>Dio Lupa</div>
-        <div class="text-xs uppercase font-semibold opacity-60">Remaining Reason</div>
+  <div class="card bg-base-100 shadow-xl animate-cartaBottom">
+    <figure class="px-10 pt-10">
+      <img src="https://img.daisyui.com/images/stock/photo-1502685104226-ee32379fefbe.jpg" alt="Profile" class="rounded-full w-32 h-32 object-cover" />
+    </figure>
+    <div class="card-body items-center text-center">
+      <h2 class="card-title text-3xl">Nacho de la Torre Planas</h2>
+      <p class="py-2">Desarrollador de aplicaciones web - fullstack</p>
+      <p class="text-sm opacity-80">
+        Full stack developer specialized in Laravel, Vue.js and Tailwind CSS. Passionate about UX/UI and mentoring new developers.
+      </p>
+      <div class="card-actions pt-4">
+        <a href="https://www.linkedin.com" target="_blank" class="btn btn-primary">LinkedIn</a>
       </div>
-      <button class="btn btn-square btn-ghost">
-        <svg class="size-[1.2em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-          <g stroke-linejoin="round" stroke-linecap="round" stroke-width="2" fill="none" stroke="currentColor">
-            <path d="M6 3L20 12 6 21 6 3z"></path>
-          </g>
-        </svg>
-      </button>
-    </li>
-
-    <li class="list-row">
-      <div class="text-4xl font-thin opacity-30 tabular-nums">02</div>
-      <div><img class="size-10 rounded-box" src="https://img.daisyui.com/images/profile/demo/4@94.webp" /></div>
-      <div class="list-col-grow">
-        <div>Ellie Beilish</div>
-        <div class="text-xs uppercase font-semibold opacity-60">Bears of a fever</div>
-      </div>
-      <button class="btn btn-square btn-ghost">
-        <svg class="size-[1.2em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-          <g stroke-linejoin="round" stroke-linecap="round" stroke-width="2" fill="none" stroke="currentColor">
-            <path d="M6 3L20 12 6 21 6 3z"></path>
-          </g>
-        </svg>
-      </button>
-    </li>
-
-    <li class="list-row">
-      <div class="text-4xl font-thin opacity-30 tabular-nums">03</div>
-      <div><img class="size-10 rounded-box" src="https://img.daisyui.com/images/profile/demo/3@94.webp" /></div>
-      <div class="list-col-grow">
-        <div>Sabrino Gardener</div>
-        <div class="text-xs uppercase font-semibold opacity-60">Cappuccino</div>
-      </div>
-      <button class="btn btn-square btn-ghost">
-        <svg class="size-[1.2em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-          <g stroke-linejoin="round" stroke-linecap="round" stroke-width="2" fill="none" stroke="currentColor">
-            <path d="M6 3L20 12 6 21 6 3z"></path>
-          </g>
-        </svg>
-      </button>
-    </li>
-
-  </ul>
+    </div>
+  </div>
 </template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
-import AppLayout from '../components/AppLayout.vue'
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -1,4 +1,15 @@
 <template>
-  2nda Pag
+  <div class="prose mx-auto p-4 max-w-2xl">
+    <h1>Sobre mí</h1>
+    <p>
+      Full stack developer specialized in Laravel, Vue.js, and Tailwind CSS, con sólidas bases en administración de sistemas y ciberseguridad (certificado en DAW y ASIR).
+      He desarrollado alrededor de 5 aplicaciones web completas, encargándome tanto del backend como del frontend con un enfoque limpio y centrado en el usuario.
+    </p>
+    <p>
+      Me apasiona la experiencia de usuario y la interfaz, siempre buscando crear soluciones simples y elegantes. Mentorizo a desarrolladores junior y estudiantes en prácticas, ayudándoles a crecer mediante aprendizaje práctico en proyectos reales.
+    </p>
+    <p>
+      Siempre aprendiendo y mejorando, enfocado en construir software fiable, escalable y fácil de usar.
+    </p>
+  </div>
 </template>
-

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -4,15 +4,14 @@ import TheFormation from '@/components/TheFormation.vue'
 </script>
 
 <template>
-  <div class="flex flex-row w-full h-full custom-bg !space-x-4 p-3">
-    <div class="w-1/2">
+  <div class="flex flex-col sm:flex-row w-full h-full custom-bg gap-4 p-3">
+    <div class="w-full sm:w-1/2">
       <ThePersonalCard />
     </div>
-    <div class="w-1/2">
+    <div class="w-full sm:w-1/2">
       <TheFormation />
     </div>
   </div>
-
 </template>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- add personal details to the portfolio cards
- show experience and education
- write an about page
- make the home layout responsive
- clean up router imports

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6848007a4424832caa524067f1097215